### PR TITLE
Fix repeated calling of contact link removal

### DIFF
--- a/src/InfectiousMatter/simulation.js
+++ b/src/InfectiousMatter/simulation.js
@@ -370,12 +370,12 @@ InfectiousMatter.prototype._default_interaction_callback  = function(this_agent_
             } else {
                 assert(ContactGraph.hasNode(this_agent_body.agent_object.uuid) && ContactGraph.hasNode(this_agent_body.agent_object.uuid));
                 this_edge = ContactGraph.addLink(this_agent_body.agent_object.uuid, other_agent.uuid, {origin:this_agent_body.agent_object.uuid, timestamp:this.cur_sim_time});
+                this.add_event( {
+                    time: this.simulation_params.link_lifetime+1, 
+                    callback: this._check_edge_for_removal(this_edge)
+                });
             }
 
-            this.add_event( {
-                time: this.simulation_params.link_lifetime+1, 
-                callback: this._check_edge_for_removal(this_edge)
-            });
         }
     );
 };


### PR DESCRIPTION
this._check_edge_for_removal(this_edg) in simulation.js is pushed to
event_queue twice for each link, because each link has two nodes, and the
function will be pushed by both nodes in one collision event. I changed
the push operation to be under if condition, so that the pushing will
only occur once.